### PR TITLE
Allow activesupport 5.0

### DIFF
--- a/ink_file_picker.gemspec
+++ b/ink_file_picker.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 3.2.14", "< 5"
+  spec.add_dependency "activesupport", ">= 3.2.14", "< 6"
   spec.add_dependency "faraday", "~> 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Tests break on travis since ActiveSupport 5.0 requires rails >= 2.2.2